### PR TITLE
Downgrade to Ghost v6.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GHOST_VERSION=6.27.0
+ARG GHOST_VERSION=6.24.0
 FROM ghost:${GHOST_VERSION}-alpine
 
 # Add the Object Store storage adapter. We use the main branch of the repository.


### PR DESCRIPTION
  * Necessitated by the fact that moving from 6.21.2 -> 6.27.0 caused migrations to break
  * The specific migration that broke was 2026-03-31-20-31-19-drop-nullable-on-automated-emails-email-design-setting-id.js which was introduced in 6.25.0 hence why we're downgrading to the version just before that
  * There is an open issue on broken migrations when moving from 6.24.0 -> 6.25.1 here: https://github.com/TryGhost/Ghost/issues/27110 which is exactly what is biting us