### PR TITLE
Ping storage-adapter to latest commit SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG GHOST_VERSION=6.44.1
 FROM ghost:${GHOST_VERSION}-alpine
 
-# Add the Object Store storage adapter. We use the main branch of the repository.
-ADD --chown=node:node https://github.com/CodeForAfrica/ghost-object-store-storage-adapter.git#main content/adapters/storage/object-store
+# Add the Object Store storage adapter.
+ADD --chown=node:node https://github.com/CodeForAfrica/ghost-object-store-storage-adapter.git#3d8cee57597e2712adbfc5e8c5d93322561b4999 content/adapters/storage/object-store
 
 # Add custom nginx configuration file to Ghost WORKDIR.
 # See https://dokku.com/docs/networking/proxies/nginx/#customizing-the-nginx-configuration for details.


### PR DESCRIPTION
  * This is the version of the adapter that updated to ghost-object-store v2.0.0
  * This should fix the failing image uploads in prod