### PR TITLE
Only accept connections from cloudflare

### DIFF
--- a/DOKKU_DEPLOYMENT.md
+++ b/DOKKU_DEPLOYMENT.md
@@ -79,6 +79,71 @@ sudo apt update && sudo apt install libnginx-mod-http-lua
 
 The Lua module should automatically be enabled via symlinking. You can confirm this by checking the contents of `/etc/nginx/modules-enabled/`.
 
+### 6. Lock the origin to Cloudflare (firewall layer)
+
+`nginx.conf.sigil` already rejects any request whose real TCP peer isn't a Cloudflare edge (the `geo $realip_remote_addr $from_cloudflare` block → `403`). Add a host firewall as a second, stronger layer so junk traffic never even reaches Nginx — this stops volumetric floods before they cost you CPU or connection slots.
+
+> [!WARNING]
+> **Do not lock yourself out.** Allow SSH (and any other admin ports) *before* enabling ufw or setting a default-deny policy. The snippet below allows port 22 first.
+
+Cloudflare publishes its ranges at <https://www.cloudflare.com/ips-v4> and <https://www.cloudflare.com/ips-v6>, and changes them occasionally, so don't hand-copy them — drive ufw from the live lists with a script.
+
+Create `/usr/local/bin/refresh-cloudflare-ufw.sh` on the Dokku host:
+
+```bash
+#!/usr/bin/env bash
+# Restrict inbound 80/443 to Cloudflare edge IPs. Idempotent: safe to re-run.
+set -euo pipefail
+
+PORTS=(80 443)
+
+# Fetch current Cloudflare ranges (fail closed — never wipe rules on a bad fetch).
+v4="$(curl -fsS https://www.cloudflare.com/ips-v4)"
+v6="$(curl -fsS https://www.cloudflare.com/ips-v6)"
+[ -n "$v4" ] && [ -n "$v6" ] || { echo "empty Cloudflare list, aborting" >&2; exit 1; }
+
+# Make sure we keep SSH before anything else.
+ufw allow 22/tcp comment 'ssh'
+
+# Drop any previous Cloudflare rules so removed ranges don't linger.
+while ufw status numbered | grep -q 'cloudflare'; do
+  n="$(ufw status numbered | grep 'cloudflare' | head -1 | sed -E 's/^\[[ ]*([0-9]+)\].*/\1/')"
+  yes | ufw delete "$n"
+done
+
+for ip in $v4 $v6; do
+  for port in "${PORTS[@]}"; do
+    ufw allow proto tcp from "$ip" to any port "$port" comment 'cloudflare'
+  done
+done
+
+# Deny direct hits to the web ports from everyone else.
+for port in "${PORTS[@]}"; do
+  ufw deny "$port/tcp" comment 'cloudflare'
+done
+
+ufw --force enable
+ufw reload
+```
+
+Run it, then confirm:
+
+```bash
+sudo chmod +x /usr/local/bin/refresh-cloudflare-ufw.sh
+sudo /usr/local/bin/refresh-cloudflare-ufw.sh
+sudo ufw status verbose
+```
+
+Keep it current with a weekly cron job (Cloudflare rarely changes ranges, but this makes it self-healing):
+
+```bash
+# /etc/cron.d/refresh-cloudflare-ufw
+0 4 * * 1 root /usr/local/bin/refresh-cloudflare-ufw.sh >> /var/log/cloudflare-ufw.log 2>&1
+```
+
+> [!NOTE]
+> The `allow from <cf-ip>` rules must sit **above** the `deny <port>` rules for ufw to match them first — the script's ordering (allows inserted before the denies are appended) handles this. Verify with `ufw status numbered`. Also keep the `set_real_ip_from` / `geo` lists in `nginx.conf.sigil` in sync with these ranges when Cloudflare updates them; both derive from the same source.
+
 ## Deploying to Dokku
 
 It is recommended that you use Docker image deployment on Dokku, as it allows you to use a pre-built Ghost image (like the one defined in this repo).

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -108,6 +108,44 @@ set_real_ip_from 2c0f:f248::/32;
 real_ip_header   CF-Connecting-IP;
 real_ip_recursive on;
 
+# Origin lockdown: is the ACTUAL TCP peer a Cloudflare edge?
+#
+# Keyed on $realip_remote_addr (the true connecting peer) and NOT $remote_addr — the realip block above rewrites $remote_addr to the visitor's
+# CF-Connecting-IP, so a check against it would reject every real Cloudflare request while doing nothing to stop a direct origin hit. The
+# ngx_http_access_module (allow/deny) has this same foot-gun under realip, which is why we use geo + a variable instead.
+#
+# Direct hits to the origin IP (someone who discovered it and is trying to bypass Cloudflare's WAF / DDoS protection / rate limiting) keep their
+# real peer address here, evaluate to 0, and get a 403 in the server blocks below.
+#
+# Keep this list in sync with the set_real_ip_from entries above — same source of truth:
+#   https://www.cloudflare.com/ips-v4
+#   https://www.cloudflare.com/ips-v6
+geo $realip_remote_addr $from_cloudflare {
+  default 0;
+  173.245.48.0/20   1;
+  103.21.244.0/22   1;
+  103.22.200.0/22   1;
+  103.31.4.0/22     1;
+  141.101.64.0/18   1;
+  108.162.192.0/18  1;
+  190.93.240.0/20   1;
+  188.114.96.0/20   1;
+  197.234.240.0/22  1;
+  198.41.128.0/17   1;
+  162.158.0.0/15    1;
+  104.16.0.0/13     1;
+  104.24.0.0/14     1;
+  172.64.0.0/13     1;
+  131.0.72.0/22     1;
+  2400:cb00::/32    1;
+  2606:4700::/32    1;
+  2803:f800::/32    1;
+  2405:b500::/32    1;
+  2405:8100::/32    1;
+  2a06:98c0::/29    1;
+  2c0f:f248::/32    1;
+}
+
 # Set up a JSON log format for better structured logging.
 log_format json escape=json
   '{'
@@ -132,6 +170,9 @@ server {
   access_log  /var/log/nginx/{{ .APP }}-access.log json;
   error_log   /var/log/nginx/{{ .APP }}-error.log;
   underscores_in_headers off;
+
+  # Reject connections that didn't come through Cloudflare (direct origin-IP hits).
+  if ($from_cloudflare = 0) { return 403; }
 
   client_body_timeout 60s;
   client_header_timeout 60s;
@@ -163,6 +204,9 @@ server {
   ssl_certificate_key {{ .APP_SSL_PATH }}/server.key;
   ssl_protocols             TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers off;
+
+  # Reject connections that didn't come through Cloudflare (direct origin-IP hits).
+  if ($from_cloudflare = 0) { return 403; }
 
   client_max_body_size 50m;
   client_body_timeout 60s;


### PR DESCRIPTION
## Summary
- Prevent attackers from bypassing Cloudflare (WAF, DDoS protection, rate limiting) by hitting the origin IP directly. `nginx.conf.sigil` now returns `403` to any request whose real TCP peer isn't a Cloudflare edge, via a `geo $realip_remote_addr $from_cloudflare` map plus an `if` guard in both server blocks. Keyed on `$realip_remote_addr` (the true peer), not `$remote_addr`, which the realip block rewrites to the visitor IP.
- Document a host firewall (ufw) as a stronger second layer in `DOKKU_DEPLOYMENT.md` — a self-healing script that restricts 80/443 to Cloudflare's live IP ranges, plus a weekly cron to keep it current.

## Test plan
- On the Dokku host, run `dokku nginx:validate-config <app>` after deploy to confirm the rendered config is valid.
- Verify a direct request to the origin IP (bypassing Cloudflare) returns `403`.
- Verify normal traffic through Cloudflare still loads, and access logs show real visitor IPs (not `403`ing legitimate requests).
- If applying the firewall: run `refresh-cloudflare-ufw.sh`, confirm `ufw status numbered` lists allow-before-deny, and that SSH is still reachable.